### PR TITLE
Update error-handler.js

### DIFF
--- a/error-handler.js
+++ b/error-handler.js
@@ -104,7 +104,7 @@ var mixIn = require('mout/object/mixIn'),
       o.serializer(body) :
       body;
 
-    res.send(statusCode, body);
+    res.status(statusCode).send(body);
   },
 
   defaults = {


### PR DESCRIPTION
res.send(statusCode,body) gives warning on Express 4, must be replaced with: res.status(statusCode).send(body);
