### PR TITLE
replace deprecated express methods

### DIFF
--- a/error-handler.js
+++ b/error-handler.js
@@ -231,10 +231,10 @@ createHandler = function createHandler(options) {
               send(statusCode, err, res, o);
             },
             text: function () {
-              res.send(statusCode);
+              res.status(statusCode).end();
             },
             html: function () {
-              res.send(statusCode);
+              res.status(statusCode).end();
             }
           });
         }


### PR DESCRIPTION
res.send(statusCode) is deprecated. I changed the format to res.status(statusCode).end()
Please pull to improve support for Express 4
