### PR TITLE
Allow Application Maintenance Mode Using 503 Response

### DIFF
--- a/README.md
+++ b/README.md
@@ -3,6 +3,21 @@ express-error-handler
 
 A graceful error handler for Express applications. This also patches a DOS exploit where users can manually trigger bad request errors that shut down your app.
 
+## About This Fork
+This fork allows for conditional maintenance mode handling.
+### Options extended
+```javascript
+// error handler options now accept an optional maintenance option
+{
+  // maintenance handlers should read values from environment
+  maintenance: {
+    // return a truthy value to enable 503 handlers that won't shutdown the app
+    enabled: function() { return true; },
+    // if 503 and maintenance enabled,
+    retryAfterSeconds: function() { return 14400; }
+  }
+}
+```
 
 ## Quick start:
 

--- a/README.md
+++ b/README.md
@@ -58,9 +58,18 @@ Here are the parameters you can pass into the `errorHandler()` middleware:
 * @param {function} [options.shutdown] An alternative shutdown function if the graceful shutdown fails.
 * @param {function} serializer a function to customize the JSON error object. Usage: serializer(err) return errObj
 * @param {function} framework Either 'express' (default) or 'restify'.
-* @param {object} [options.maintenance] Allow a maintenance mode 503 response without app shutdown.
-  - options.maintenance.enabled {function} Return truthy to enable maintenance mode and prevent app shutdown.
-  - options.maintenance.retryAfterSeconds {function} Return number of seconds {number} to specify in 'Retry-After' header.
+
+* @param {object} [options.maintenance]
+
+Allows a maintenance mode 503 response without app shutdown. Default members use environment variables named:
+  - `ERR_HANDLER_MAINT_ENABLED` Considered true if set to any value except 'no', '0', 'false', '', 'undefined'.
+  - `ERR_HANDLER_MAINT_RETRYAFTER` Can be a value in seconds (for relative) or an HTTP compliant GMT date (for absolute). Defaults to 3600 seconds.
+
+* @member {function} [options.maintenance.enabled] Return truthy to enable maintenance mode and prevent app shutdown.
+* @member {function} [options.maintenance.retryAfter]  Return value {number|HTTP_Date} to specify in 'Retry-After' header.
+[HTTP 503 Reference](http://www.w3.org/Protocols/rfc2616/rfc2616-sec10.html#sec10.5.4)
+[Retry-After Reference](http://www.w3.org/Protocols/rfc2616/rfc2616-sec14.html#sec14.37)
+
 * @return {function} errorHandler Express error handling middleware.
 
 ### Examples:
@@ -126,7 +135,10 @@ errorHandler.isClientError(404); // returns true
 errorHandler.isClientError(500); // returns false
 ```
 
-## errorHandler.isMaintenance(status)
+## errorHandler.maintenance
+
+### errorHandler.maintenance([message])
+Returns the middleware for conditionally skipping to the errorHandler middleware
 
 Return true if the error status can represent a maintenance condition and a maintenance condition is enabled.
 If isMaintenance returns true, the error status will not trigger a restart.
@@ -140,7 +152,6 @@ errorHandler.isMaintenance(503); // returns true if options.maintenance.enabled 
 errorHandler.isMaintenance(503); // returns false if options.maintenance.enabled returns falsey
 errorHandler.isMaintenance(500); // always returns false
 ```
-
 
 ## errorHandler.httpError(status, [message])
 

--- a/README.md
+++ b/README.md
@@ -3,22 +3,6 @@ express-error-handler
 
 A graceful error handler for Express applications. This also patches a DOS exploit where users can manually trigger bad request errors that shut down your app.
 
-## About This Fork
-This fork allows for conditional maintenance mode handling.
-### Options extended
-```javascript
-// error handler options now accept an optional maintenance option
-{
-  // maintenance handlers should read values from environment
-  maintenance: {
-    // return a truthy value to enable 503 handlers that won't shutdown the app
-    enabled: function() { return true; },
-    // if 503 and maintenance enabled,
-    retryAfterSeconds: function() { return 14400; }
-  }
-}
-```
-
 ## Quick start:
 
 ```js
@@ -74,6 +58,9 @@ Here are the parameters you can pass into the `errorHandler()` middleware:
 * @param {function} [options.shutdown] An alternative shutdown function if the graceful shutdown fails.
 * @param {function} serializer a function to customize the JSON error object. Usage: serializer(err) return errObj
 * @param {function} framework Either 'express' (default) or 'restify'.
+* @param {object} [options.maintenance] Allow a maintenance mode 503 response without app shutdown.
+  - options.maintenance.enabled {function} Return truthy to enable maintenance mode and prevent app shutdown.
+  - options.maintenance.retryAfterSeconds {function} Return number of seconds {number} to specify in 'Retry-After' header.
 * @return {function} errorHandler Express error handling middleware.
 
 ### Examples:
@@ -137,6 +124,21 @@ Return true if the error status represents a client error that should not trigge
 ```js
 errorHandler.isClientError(404); // returns true
 errorHandler.isClientError(500); // returns false
+```
+
+## errorHandler.isMaintenance(status)
+
+Return true if the error status can represent a maintenance condition and a maintenance condition is enabled.
+If isMaintenance returns true, the error status will not trigger a restart.
+
++ @param {number} status
++ @returns {boolean}
+
+### Example
+```js
+errorHandler.isMaintenance(503); // returns true if options.maintenance.enabled returns truthy
+errorHandler.isMaintenance(503); // returns false if options.maintenance.enabled returns falsey
+errorHandler.isMaintenance(500); // always returns false
 ```
 
 

--- a/error-handler.js
+++ b/error-handler.js
@@ -92,92 +92,6 @@ var mixIn = require('mout/object/mixIn'),
     };
   },
 
-  /**
-   * The default management of the maintenance state.
-   * If no arguments, reads ERR_HANDLER_MAINT_ENABLED environment 
-   * variable to determine if maintenance is enabled.
-   *
-   * If a state is supplied, set the environment variable
-   * and return the new enabled state.
-   *
-   * If the env var contains a reasonable value that denotes
-   * a disabled condition, that is honored.
-   *
-   * @param {string} The new state to set ERR_HANDLER_MAINT_ENABLED to
-   * @returns {boolean} True if maintenance is enabled, false otherwise
-   */
-  maintenanceState = function maintenanceState(state) {
-    if (arguments.length > 0) {
-      process.env.ERR_HANDLER_MAINT_ENABLED = state;
-    }
-    var value = process.env.ERR_HANDLER_MAINT_ENABLED;
-    var negative = {
-      '0': true, 'false': true, 'no': true, 'undefined': true
-    };
-    return !!(value && !negative[value.toLowerCase()]);
-  },
-
-  /**
-   * Get the default maintenance Retry-After value.
-   * Uses a fallback of 3600 seconds (1 hour) because
-   * this function is called only if the user has set 
-   * the maintenance to enabled (and therefore wants
-   * a maintenance response to occur).
-   *
-   * If the server responds with a 503 and no Retry-After
-   * header, the client treats it as a 500 per HTTP spec.
-   *
-   * Value can be seconds from now (for a relative Retry-After),
-   * or an HTTP-date (RFC2822 GMT per spec, but ISO 8601 or 
-   * other form may be preferable). Assume user knows best.
-   *
-   * @returns The value for the Retry-After response header.
-   */
-  maintenanceRetryAfter = function maintenanceRetryAfter() {
-    var result, value = process.env.ERR_HANDLER_MAINT_RETRYAFTER;
-    // fallback b/c user wants maintenance & no Retry-After means 500
-    var fallback = 3600;
-    // First, try seconds
-    result = parseInt(value, 10);
-    result = (result === 0 || (result && result < 0)) ? fallback : result;
-    if (!result) {
-      // NaN, try date
-      result = Date.parse(value) && value || fallback;
-    }
-    return result;
-  },
-
-  /**
-   * Takes an optional message and returns middleware
-   * to conditionally invoke the errorHandler if 
-   * maintenance is enabled.
-   *
-   * About getEnabled
-   * If this is called after the errorHandler is created,
-   * use the possibly overriden enabled method.
-   * Otherwise use the default method.
-   *
-   * @param {string} message
-   * @returns {function} conditional maintenance middleware
-   */
-  maintenance = function maintenance(message) {
-    return function conditional503(req, res, next) {
-      var err;
-      var getEnabled = 
-        (typeof maintenance._maintEnabled === 'function' && 
-         maintenance._maintEnabled) ||
-        maintenanceState;
-
-      if (getEnabled()) {
-        err = new Error();
-        err.status = 503;
-        err.message = message ||
-          statusCodes[err.status];
-      }
-      next(err);
-    };
-  },
-
   sendFile = function sendFile (staticFile, res) {
     var filePath = path.resolve(staticFile),
       stream = fs.createReadStream(filePath);
@@ -208,11 +122,7 @@ var mixIn = require('mout/object/mixIn'),
     server: undefined,
     shutdown: undefined,
     serializer: undefined,
-    framework: 'express',
-    maintenance: {
-      enabled: maintenanceState,
-      retryAfter: maintenanceRetryAfter
-    }
+    framework: 'express'
   },
   createHandler;
 
@@ -257,13 +167,6 @@ var mixIn = require('mout/object/mixIn'),
  * @param {function} framework Either 'express'
  *        (default) or 'restify'.
  *
- * @param {object} [options.maintenance] Optionally override
- *        the default maintenance state management.
- * @member {function} [options.maintenance.enabled]
- * @returns True if maintenance mode is enabled, false otherwise.
- * @member {function} [options.maintenance.retryAfter]
- * @returns The value for the Retry-After response header.
- *
  * @return {function} errorHandler Express error 
  *         handling middleware.
  */
@@ -286,34 +189,9 @@ createHandler = function createHandler(options) {
       }, o.timeout);
 
     },
-    /**
-     * Test if maintenance condition exists.
-     * @param {number} status
-     * @returns {boolean} true if maintenance condition
-     */
-    isMaintenance = function isMaintenance(status){
-      return (status === 503 &&
-        typeof o.maintenance.enabled === 'function' &&
-        o.maintenance.enabled()
-        );
-    },
-    /**
-     * Make a response header for maintenance condition.
-     * If retryAfter returns falsey, don't add header.
-     * @returns {object} Retry-After response header
-     */
-    maintHeader = function maintHeader(){
-      var retryAfter = (typeof o.maintenance.retryAfter === 'function' &&
-        o.maintenance.retryAfter());
-      return retryAfter ? { 'Retry-After': retryAfter } : {};
-    },
-
     express = o.framework === 'express',
     restify = o.framework === 'restify',
     errorHandler;
-
-  // Update the maintenance API.
-  maintenance._maintEnabled = o.maintenance.enabled;
 
   /**
    * Express error handler to handle any
@@ -380,9 +258,17 @@ createHandler = function createHandler(options) {
         }
       },
 
+      shouldContinue = function
+          shouldContinue(status) {
+        var isMaintenance = 
+          typeof createHandler.maintenance._isMaintenance === 'function' &&
+          createHandler.maintenance._isMaintenance(status);
+        return isClientError(status) || isMaintenance;
+      },
+
       resumeOrClose = function
           resumeOrClose(status) {
-        if (!isClientError(status) && !isMaintenance(status)) {
+        if (!shouldContinue(status)) {
           return close(o, exit);
         }
       };
@@ -391,14 +277,9 @@ createHandler = function createHandler(options) {
       return resumeOrClose(status);
     }
 
-    // If maintenance, set maintenance response header.
-    if (isMaintenance(status)) {
-      res.header(maintHeader());
-    }
-
-    // Always set a status.
+    // Always set a response status.
     res.status(status);
-
+    
     // If there's a custom handler defined,
     // use it and return.
     if (typeof handler === 'function') {
@@ -428,7 +309,7 @@ createHandler = function createHandler(options) {
     // attackers can send malformed requests
     // for the purpose of creating a Denial 
     // Of Service (DOS) attack.
-    if (isClientError(status) || isMaintenance(status)) {
+    if (shouldContinue(status)) {
       return renderDefault(status);
     }
 
@@ -450,46 +331,81 @@ createHandler = function createHandler(options) {
   }
 };
 
-// The Maintenance API
-maintenance.status = function(state) {
-  var enabledDefined = typeof this._maintEnabled === 'function';
-  var enabled = enabledDefined ? this._maintEnabled() : false;
+/**
+ * Maintenance middleware
+ * 
+ * @param {object} [options]
+ *
+ * @param {function} [options.status] - Returns Boolean to indicate
+ * the application is in maintenance mode. Default reads 
+ * ERR_HANDLER_MAINT_ENABLED environment variable - Value must be
+ * 'TRUE' to indicate an active maintenance condition, any other value 
+ * is false.
+ *
+ * @param {function} [options.retryAfter] - Returns
+ * Number or String value for Retry-After response header.
+ * Default reads ERR_HANDLER_MAINT_RETRYAFTER environment variable -
+ * Value must be a positive integer for retry after relative seconds,
+ * or an HTTP-date in GMT to indicate an absolte retry after period.
+ *
+ * @see http://www.w3.org/Protocols/rfc2616/rfc2616-sec10.html#sec10.5.4
+ * @see http://www.w3.org/Protocols/rfc2616/rfc2616-sec14.html#sec14.37
+ */
+createHandler.maintenance = function maintenance(options) {
+  options = options || {};
 
-  // A word on using the state argument.
-  // This is useful to manage the state in this one process environment.
-  // If you are using a service provider with multiple processes
-  // that maybe go up and down
-  // *don't use this function to set the maintenance state*
-  // In other words: Don't supply a state argument, ever.
-  // Instead use your provider's controlpanel/command to set the environment var
-  // for your Computing/Dyno/Whatever instances.
-  if (arguments.length > 0) {
+  var
+    status = typeof options.status === 'function' ?
+      options.status :
+      function status () {
+        return ('' + process.env.ERR_HANDLER_MAINT_ENABLED)
+          .trim().toLowerCase() === 'true';
+      },
 
-    if (enabledDefined && this._maintEnabled !== maintenanceState) {
-      // The Courtesy Throw
-      // If options.maintenance.enabled has been overridden,
-      // the user already manages the state, so this was a mistake.
-      // Reason: 
-      // The user has told us they manage the maintenance state elsewhere.
-      // Argument:
-      // Why would the user manage their own state, then give us their
-      // management callback *AND THEN* use this lib to call their own
-      // callback? (nonsense, I say. E_IRRELEVANT_COUPLING)
-      throw new Error(
-        'options.maintenance.enabled was overridden, '+
-        'so the caller manages the maintenance state.'
-      );
+    retryAfter = typeof options.retryAfter === 'function' ?
+      options.retryAfter :
+      function retryAfter() {
+        var result,
+            value = ('' + process.env.ERR_HANDLER_MAINT_RETRYAFTER).trim();
+        // fallback b/c user wants maintenance & no Retry-After means 500
+        var fallback = 3600;
+        // First, try seconds
+        result = parseInt(value, 10);
+        result = (result === 0 || (result && result < 0)) ? fallback : result;
+        if (!result) {
+          // NaN, try date
+          result = Date.parse(value) && value || fallback;
+        }
+        return result;
+      };
+
+  // Expose maintenance utility to errorHandler
+  createHandler.maintenance._isMaintenance = 
+    function _isMaintenance(statusCode) {
+      return (statusCode === 503 && status());
+    };
+
+  // Update exposed status method to any 503 handlers
+  createHandler.maintenance.status = status;
+
+  return function maintenanceMiddleware(req, res, next) {
+    var
+      maintenanceMode = function maintenanceMode() {
+        res.header({ 'Retry-After': retryAfter() });
+        return httpError(503)(req, res, next);
+      };
+
+    if ( status() ) {
+      return maintenanceMode();
+    } else {
+      return next();
     }
+  };
+};
+// Updated if user creates maintenance middleware.
+createHandler.maintenance.status = function() { return false; };
 
-    // Yep, call the default (see above test and explanation)
-    enabled = maintenanceState(state);
-  }
-
-  return enabled; 
-}.bind(maintenance);
-createHandler.maintenance = maintenance;
-
-// Client Error Functions
+// isClientError functions
 createHandler.isClientError = isClientError;
 createHandler.clientError = function () {
   var args = [].slice.call(arguments);

--- a/error-handler.js
+++ b/error-handler.js
@@ -191,18 +191,19 @@ createHandler = function createHandler(options) {
 
     },
     /**
-     * Test if maintenance condition exists
+     * Test if maintenance condition exists.
      * @param {number} status
      * @returns {boolean} true if maintenance condition
      */
     isMaintenance = function isMaintenance(status){
       return (status === 503 &&
-        typeof o.maintenance.enable === 'function' &&
-        o.maintenance.enable()
+        typeof o.maintenance.enabled === 'function' &&
+        o.maintenance.enabled()
         );
     },
     /**
-     * Make a response header for maintenance condition
+     * Make a response header for maintenance condition.
+     * If retryAfterSeconds returns falsey, don't add header.
      * @returns {object} Retry-After response header
      */
     maintHeader = function maintHeader(){
@@ -215,7 +216,7 @@ createHandler = function createHandler(options) {
     restify = o.framework === 'restify',
     errorHandler;
 
-  // Update the exposed maintenance test
+  // Update the exposed maintenance test.
   createHandler.isMaintenance = isMaintenance;
 
   /**
@@ -294,12 +295,12 @@ createHandler = function createHandler(options) {
       return resumeOrClose(status);
     }
 
-    // If maintenance, set maintenance response header
+    // If maintenance, set maintenance response header.
     if (isMaintenance(status)) {
       res.header(maintHeader());
     }
 
-    // Always set a status
+    // Always set a status.
     res.status(status);
 
     // If there's a custom handler defined,
@@ -353,7 +354,9 @@ createHandler = function createHandler(options) {
   }
 };
 
+// This is updated once the error handler is created.
 createHandler.isMaintenance = function() { return false; };
+
 createHandler.isClientError = isClientError;
 createHandler.clientError = function () {
   var args = [].slice.call(arguments);

--- a/error-handler.js
+++ b/error-handler.js
@@ -244,10 +244,6 @@ createHandler = function createHandler(options) {
 
         res.statusCode = statusCode;
 
-        if (isMaintenance(statusCode)) {
-          res.header(maintHeader());
-        }
-
         if (defaultView) {
           return res.render(defaultView, err);
         }
@@ -296,6 +292,11 @@ createHandler = function createHandler(options) {
 
     if (!res) {
       return resumeOrClose(status);
+    }
+
+    // If maintenance, set maintenance response header
+    if (isMaintenance(status)) {
+      res.header(maintHeader());
     }
 
     // If there's a custom handler defined,

--- a/error-handler.js
+++ b/error-handler.js
@@ -299,6 +299,9 @@ createHandler = function createHandler(options) {
       res.header(maintHeader());
     }
 
+    // Always set a status
+    res.status(status);
+
     // If there's a custom handler defined,
     // use it and return.
     if (typeof handler === 'function') {

--- a/examples/maintenance.js
+++ b/examples/maintenance.js
@@ -14,9 +14,7 @@ var express = require('express'),
 // ...
 
 // Send the app into maintenance mode using env.ERR_HANDLER_MAINT_ENABLED
-// Unset env.ERR_HANDLER_MAINT_ENABLED to disable.
-// Or use the Maintenance API to get/set the env variable for this process:
-// errorHandler.maintenance.status([true|false])
+// env.ERR_HANDLER_MAINT_ENABLED must be equal to TRUE to enable maintenance.
 app.use(errorHandler.maintenance());
 
 //
@@ -34,9 +32,7 @@ server = http.createServer(app);
 // The 503 maintenance response will send the Retry-After header
 // using the value set in env.ERR_HANDLER_MAINT_RETRYAFTER.
 // Value can be seconds or HTTP-Date (GMT).
-// For more info:
-//   503: http://www.w3.org/Protocols/rfc2616/rfc2616-sec10.html#sec10.5.4
-//   Retry-After: http://www.w3.org/Protocols/rfc2616/rfc2616-sec14.html#sec14.37
+// This example will respond to any 503 with the 503 page.
 app.use(errorHandler({
   server: server,
   static: {

--- a/examples/maintenance.js
+++ b/examples/maintenance.js
@@ -1,0 +1,53 @@
+'use strict';
+
+var express = require('express'),
+  errorHandler = require('../error-handler.js'),
+  app = express(),
+  env = process.env,
+  port = env.PORT || 3000,
+  http = require('http'),
+  server;
+
+// Send the app into maintenance mode from env.MAINT_FLAG.
+// Unset env.MAINT_FLAG to disable.
+app.use((function() {
+  return env.MAINT_FLAG ? errorHandler.httpError(503) :
+    function skippy(req, res, next) { return next(); };
+}()));
+
+//
+// ... other middleware here...
+// This middleware would be skipped in maintenance mode.
+//
+
+// Create the server object that we can pass
+// in to the error handler:
+server = http.createServer(app);
+
+// Respond to errors and conditionally shutdown the server.
+// Enable 503 maintenance with Retry-After responses with env.MAINT_FLAG.
+// Will not shutdown server if maintenance is enabled.
+app.use(errorHandler({
+  server: server,
+  maintenance: {
+    enabled: function() {
+      // Use environment variable to send a maintenance response
+      //  on a 503 status.
+      // Unset the environment variable to disable maintenance.
+      return env.MAINT_FLAG;
+    },
+    retryAfterSeconds: function() {
+      // Specify retry after time in seconds, default to 1 hour.
+      return env.MAINT_RETRYAFTER || 3600;
+    }
+  },
+  static: {
+    // Replace these with paths that work
+    '404': 'path/to/404.html',
+    '503': 'path/to/503.html'
+  }
+}));
+
+server.listen(port, function () {
+  console.log('Listening on port ' + port);
+});

--- a/examples/maintenance.js
+++ b/examples/maintenance.js
@@ -8,39 +8,37 @@ var express = require('express'),
   http = require('http'),
   server;
 
-// Send the app into maintenance mode from env.MAINT_FLAG.
-// Unset env.MAINT_FLAG to disable.
-app.use((function() {
-  return env.MAINT_FLAG ? errorHandler.httpError(503) :
-    function skippy(req, res, next) { return next(); };
-}()));
+//
+// Any middleware here will always execute.
+// app.use(middleware);
+// ...
+
+// Send the app into maintenance mode using env.ERR_HANDLER_MAINT_ENABLED
+// Unset env.ERR_HANDLER_MAINT_ENABLED to disable.
+// Or use the Maintenance API to get/set the env variable for this process:
+// errorHandler.maintenance.status([true|false])
+app.use(errorHandler.maintenance());
 
 //
-// ... other middleware here...
-// This middleware would be skipped in maintenance mode.
-//
+// Middleware here will be skipped in maintenance mode.
+// app.use(othermiddleware1);
+// app.use(othermiddleware2);
+// ...
 
 // Create the server object that we can pass
 // in to the error handler:
 server = http.createServer(app);
 
 // Respond to errors and conditionally shutdown the server.
-// Enable 503 maintenance with Retry-After responses with env.MAINT_FLAG.
 // Will not shutdown server if maintenance is enabled.
+// The 503 maintenance response will send the Retry-After header
+// using the value set in env.ERR_HANDLER_MAINT_RETRYAFTER.
+// Value can be seconds or HTTP-Date (GMT).
+// For more info:
+//   503: http://www.w3.org/Protocols/rfc2616/rfc2616-sec10.html#sec10.5.4
+//   Retry-After: http://www.w3.org/Protocols/rfc2616/rfc2616-sec14.html#sec14.37
 app.use(errorHandler({
   server: server,
-  maintenance: {
-    enabled: function() {
-      // Use environment variable to send a maintenance response
-      //  on a 503 status.
-      // Unset the environment variable to disable maintenance.
-      return env.MAINT_FLAG;
-    },
-    retryAfterSeconds: function() {
-      // Specify retry after time in seconds, default to 1 hour.
-      return env.MAINT_RETRYAFTER || 3600;
-    }
-  },
   static: {
     // Replace these with paths that work
     '404': 'path/to/404.html',


### PR DESCRIPTION
First, thanks for this tool, it's very useful.

For apps that would like to set a temporary maintenance condition, it would be really handy to be able to set a 503 maintenance response and not have to disagree with the default handling of 500+ responses by this tool. In the temporary maintenance condition, you don't want the app to shutdown, but rather to serve the 503 maintenance response and remain in that state until you've completed maintenance.

Here's a PR of a fork that I'm using to deal with this in one of my apps. Integrating with this lib is a very clean solution for this. I've included tests, updated readme, and a detailed example that shows how to use the maintenance option with the environment to enter/exit the temporary maintenance condition.

I also found a problem where the http error status was not being set when not using the `renderDefault`. In my case, it was when serving static 404.html, 503.html. In those instances, the resource would be served with an http response of 200. So I added a one-liner to always set a representative error status (which can be overwritten in later processing paths as the current code does).

Let me know what you think.
Thanks,
Alex